### PR TITLE
feat: show weekly agenda for psychologists

### DIFF
--- a/sys_beneficiarios/resources/views/dashboard.blade.php
+++ b/sys_beneficiarios/resources/views/dashboard.blade.php
@@ -1,17 +1,50 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Dashboard') }}
+        <h2 class="h5 mb-0">
+            {{ auth()->user()->hasRole('psicologo') ? __('Mis pacientes') : __('Dashboard') }}
         </h2>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900">
-                    {{ __("You're logged in!") }}
-                </div>
-            </div>
+    @role('psicologo')
+    <div class="card">
+        <div class="card-body" id="agenda-container">
+            <div class="text-muted">Cargando…</div>
         </div>
     </div>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+        try {
+            const res = await fetch('/s360/psico/agenda-semana');
+            const data = await res.json();
+            const container = document.getElementById('agenda-container');
+            const items = data.items || [];
+            if (!items.length) {
+                container.innerHTML = '<div class="text-muted">No hay citas para esta semana.</div>';
+                return;
+            }
+            const rows = items.map(item => {
+                const badgeClass = item.estado === 'atendido' ? 'bg-success' : 'bg-warning text-dark';
+                const estadoText = item.estado === 'atendido' ? 'Atendido' : 'Pendiente';
+                return `<li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>${item.nombre}</span>
+                    <div>
+                        <span class="badge ${badgeClass} me-2">${estadoText}</span>
+                        <span class="text-muted">${item.fecha}</span>
+                    </div>
+                </li>`;
+            }).join('');
+            container.innerHTML = `<ul class="list-group">${rows}</ul>`;
+        } catch (e) {
+            document.getElementById('agenda-container').innerHTML = '<div class="text-danger">Error al cargar la agenda.</div>';
+        }
+    });
+    </script>
+    @else
+    <div class="card">
+        <div class="card-body">
+            {{ __("You're logged in!") }}
+        </div>
+    </div>
+    @endrole
 </x-app-layout>

--- a/sys_beneficiarios/resources/views/layouts/navigation.blade.php
+++ b/sys_beneficiarios/resources/views/layouts/navigation.blade.php
@@ -17,6 +17,8 @@
                         <a class="nav-link {{ request()->routeIs('encargado.home') ? 'active' : '' }}" href="{{ route('encargado.home') }}">{{ __('Dashboard') }}</a>
                     @elseif(Auth::user() && Auth::user()->hasRole('capturista'))
                         <a class="nav-link {{ request()->routeIs('capturista.home') ? 'active' : '' }}" href="{{ route('capturista.home') }}">{{ __('Dashboard') }}</a>
+                    @elseif(Auth::user() && Auth::user()->hasRole('psicologo'))
+                        <a class="nav-link {{ request()->routeIs('dashboard') ? 'active' : '' }}" href="{{ route('dashboard') }}">{{ __('Mis Pacientes') }}</a>
                     @else
                         <a class="nav-link {{ request()->routeIs('dashboard') ? 'active' : '' }}" href="{{ route('dashboard') }}">{{ __('Dashboard') }}</a>
                     @endif
@@ -30,9 +32,11 @@
                     @endif
                 </li>
                 @endrole
+                @if(!Auth::user() || !Auth::user()->hasRole('psicologo'))
                 <li class="nav-item">
                     <a class="nav-link {{ request()->routeIs('beneficiarios.create') ? 'active' : '' }}" href="{{ route('beneficiarios.create') }}">{{ __('Captura') }}</a>
                 </li>
+                @endif
                 @role('admin|encargado')
                 <li class="nav-item">
                     <a class="nav-link {{ request()->routeIs('domicilios.*') ? 'active' : '' }}" href="{{ route('domicilios.index') }}">{{ __('Domicilios') }}</a>


### PR DESCRIPTION
## Summary
- display "Mis pacientes" on psychologist dashboard with weekly agenda and status badges
- replace dashboard nav label with "Mis Pacientes" for psychologists
- hide "Captura" link from psychologist navbar

## Testing
- `php artisan test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e580df78832fbb6e6647b15ddb68