### PR TITLE
Add feature test for admin user creation

### DIFF
--- a/sys_beneficiarios/tests/Feature/Admin/UserManagementTest.php
+++ b/sys_beneficiarios/tests/Feature/Admin/UserManagementTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+uses(TestCase::class, RefreshDatabase::class);
+
+beforeEach(function () {
+    foreach (['admin', 'capturista', 'encargado_360', 'encargado_bienestar', 'psicologo'] as $role) {
+        Role::firstOrCreate([
+            'name' => $role,
+            'guard_name' => 'web',
+        ]);
+    }
+
+    $this->admin = User::factory()->create();
+    $this->admin->assignRole('admin');
+});
+
+it('permite a un administrador crear un nuevo usuario', function () {
+    $response = $this->actingAs($this->admin)->post('/admin/usuarios', [
+        'name' => 'Nuevo Usuario',
+        'email' => 'nuevo@example.com',
+        'password' => 'Password1',
+        'role' => 'capturista',
+    ]);
+
+    $response->assertRedirect(route('admin.usuarios.index'));
+    $response->assertSessionHas('status', 'Usuario creado correctamente');
+
+    $user = User::where('email', 'nuevo@example.com')->first();
+
+    expect($user)->not->toBeNull();
+    expect($user->name)->toBe('Nuevo Usuario');
+    expect(Hash::check('Password1', $user->password))->toBeTrue();
+    expect($user->hasRole('capturista'))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- add a feature test that covers creating a new user from the admin panel
- assert the new user is saved with the expected data, hashed password, and assigned role

## Testing
- php artisan test --filter=UserManagementTest

------
https://chatgpt.com/codex/tasks/task_e_68dc68949880832fb36b95f03fe96189